### PR TITLE
etcdctl: add learner field in member list output

### DIFF
--- a/etcdctl/ctlv3/command/member_command.go
+++ b/etcdctl/ctlv3/command/member_command.go
@@ -90,7 +90,7 @@ func NewMemberListCommand() *cobra.Command {
 		Use:   "list",
 		Short: "Lists all members in the cluster",
 		Long: `When --write-out is set to simple, this command prints out comma-separated member lists for each endpoint.
-The items in the lists are ID, Status, Name, Peer Addrs, Client Addrs.
+The items in the lists are ID, Status, Name, Peer Addrs, Client Addrs, Is Learner.
 `,
 
 		Run: memberListCommandFunc,

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -158,11 +158,15 @@ func (p *printerUnsupported) DBStatus(snapshot.Status)  { p.p(nil) }
 func (p *printerUnsupported) MoveLeader(leader, target uint64, r v3.MoveLeaderResponse) { p.p(nil) }
 
 func makeMemberListTable(r v3.MemberListResponse) (hdr []string, rows [][]string) {
-	hdr = []string{"ID", "Status", "Name", "Peer Addrs", "Client Addrs"}
+	hdr = []string{"ID", "Status", "Name", "Peer Addrs", "Client Addrs", "Is Learner"}
 	for _, m := range r.Members {
 		status := "started"
 		if len(m.Name) == 0 {
 			status = "unstarted"
+		}
+		isLearner := "false"
+		if m.IsLearner {
+			isLearner = "true"
 		}
 		rows = append(rows, []string{
 			fmt.Sprintf("%x", m.ID),
@@ -170,6 +174,7 @@ func makeMemberListTable(r v3.MemberListResponse) (hdr []string, rows [][]string
 			m.Name,
 			strings.Join(m.PeerURLs, ","),
 			strings.Join(m.ClientURLs, ","),
+			isLearner,
 		})
 	}
 	return hdr, rows

--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -137,6 +137,7 @@ func (p *fieldsPrinter) MemberList(r v3.MemberListResponse) {
 		for _, u := range m.ClientURLs {
 			fmt.Printf("\"ClientURL\" : %q\n", u)
 		}
+		fmt.Println(`"IsLearner" :`, m.IsLearner)
 		fmt.Println()
 	}
 }


### PR DESCRIPTION
Adding learner field to `etcdctl member list` output. 

Example output:
```
$ etcdctl member list
8211f1d0f64f3269, started, infra1, http://127.0.0.1:12380, http://127.0.0.1:2379, false
e97e1efd287f528f, started, infra2, http://127.0.0.1:22380, http://127.0.0.1:22379, true
```
```
$ etcdctl member list -w table
+------------------+---------+--------+------------------------+------------------------+------------+
|        ID        | STATUS  |  NAME  |       PEER ADDRS       |      CLIENT ADDRS      | IS LEARNER |
+------------------+---------+--------+------------------------+------------------------+------------+
| 8211f1d0f64f3269 | started | infra1 | http://127.0.0.1:12380 |  http://127.0.0.1:2379 |      false |
| e97e1efd287f528f | started | infra2 | http://127.0.0.1:22380 | http://127.0.0.1:22379 |       true |
+------------------+---------+--------+------------------------+------------------------+------------+
```
```
$ etcdctl member list -w json
{"header":{"cluster_id":8228326457201596175,"member_id":9372538179322589801,"raft_term":2},"members":[{"ID":9372538179322589801,"name":"infra1","peerURLs":["http://127.0.0.1:12380"],"clientURLs":["http://127.0.0.1:2379"]},{"ID":16824919330557743759,"name":"infra2","peerURLs":["http://127.0.0.1:22380"],"clientURLs":["http://127.0.0.1:22379"],"isLearner":true}]}
```
```
$ etcdctl member list -w fields
"ClusterID" : 8228326457201596175
"MemberID" : 9372538179322589801
"Revision" : 0
"RaftTerm" : 2
"ID" : 9372538179322589801
"Name" : "infra1"
"PeerURL" : "http://127.0.0.1:12380"
"ClientURL" : "http://127.0.0.1:2379"
"IsLearner" : false

"ID" : 16824919330557743759
"Name" : "infra2"
"PeerURL" : "http://127.0.0.1:22380"
"ClientURL" : "http://127.0.0.1:22379"
"IsLearner" : true

```