### PR TITLE
*: Add learner field to endpoint status API

### DIFF
--- a/etcdctl/ctlv3/command/ep_command.go
+++ b/etcdctl/ctlv3/command/ep_command.go
@@ -60,7 +60,7 @@ func newEpStatusCommand() *cobra.Command {
 		Use:   "status",
 		Short: "Prints out the status of endpoints specified in `--endpoints` flag",
 		Long: `When --write-out is set to simple, this command prints out comma-separated status lists for each endpoint.
-The items in the lists are endpoint, ID, version, db size, is leader, raft term, raft index.
+The items in the lists are endpoint, ID, version, db size, is leader, is learner, raft term, raft index, raft applied index, errors.
 `,
 		Run: epStatusCommandFunc,
 	}

--- a/etcdctl/ctlv3/command/printer.go
+++ b/etcdctl/ctlv3/command/printer.go
@@ -194,7 +194,8 @@ func makeEndpointHealthTable(healthList []epHealth) (hdr []string, rows [][]stri
 }
 
 func makeEndpointStatusTable(statusList []epStatus) (hdr []string, rows [][]string) {
-	hdr = []string{"endpoint", "ID", "version", "db size", "is leader", "raft term", "raft index", "raft applied index", "errors"}
+	hdr = []string{"endpoint", "ID", "version", "db size", "is leader", "is learner", "raft term",
+		"raft index", "raft applied index", "errors"}
 	for _, status := range statusList {
 		rows = append(rows, []string{
 			status.Ep,
@@ -202,6 +203,7 @@ func makeEndpointStatusTable(statusList []epStatus) (hdr []string, rows [][]stri
 			status.Resp.Version,
 			humanize.Bytes(uint64(status.Resp.DbSize)),
 			fmt.Sprint(status.Resp.Leader == status.Resp.Header.MemberId),
+			fmt.Sprint(status.Resp.IsLearner),
 			fmt.Sprint(status.Resp.RaftTerm),
 			fmt.Sprint(status.Resp.RaftIndex),
 			fmt.Sprint(status.Resp.RaftAppliedIndex),

--- a/etcdctl/ctlv3/command/printer_fields.go
+++ b/etcdctl/ctlv3/command/printer_fields.go
@@ -158,6 +158,7 @@ func (p *fieldsPrinter) EndpointStatus(eps []epStatus) {
 		fmt.Printf("\"Version\" : %q\n", ep.Resp.Version)
 		fmt.Println(`"DBSize" :`, ep.Resp.DbSize)
 		fmt.Println(`"Leader" :`, ep.Resp.Leader)
+		fmt.Println(`"IsLearner" :`, ep.Resp.IsLearner)
 		fmt.Println(`"RaftIndex" :`, ep.Resp.RaftIndex)
 		fmt.Println(`"RaftTerm" :`, ep.Resp.RaftTerm)
 		fmt.Println(`"RaftAppliedIndex" :`, ep.Resp.RaftAppliedIndex)

--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -693,3 +693,22 @@ func mustDetectDowngrade(lg *zap.Logger, cv *semver.Version) {
 		}
 	}
 }
+
+// IsLearner returns if the local member is raft learner
+func (c *RaftCluster) IsLearner() bool {
+	c.Lock()
+	defer c.Unlock()
+	localMember, ok := c.members[c.localID]
+	if !ok {
+		if c.lg != nil {
+			c.lg.Panic(
+				"failed to find local ID in cluster members",
+				zap.String("cluster-id", c.cid.String()),
+				zap.String("local-member-id", c.localID.String()),
+			)
+		} else {
+			plog.Panicf("failed to find local ID %s in cluster %s", c.localID.String(), c.cid.String())
+		}
+	}
+	return localMember.IsLearner
+}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -2440,3 +2440,8 @@ func (s *EtcdServer) Alarms() []*pb.AlarmMember {
 func (s *EtcdServer) Logger() *zap.Logger {
 	return s.lg
 }
+
+// IsLearner returns if the local member is raft learner
+func (s *EtcdServer) IsLearner() bool {
+	return s.cluster.IsLearner()
+}


### PR DESCRIPTION
Added learner field to endpoint status API.

Example output:
```
$ etcdctl endpoint status -w table --cluster
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+------------+
|        ENDPOINT        |        ID        |  VERSION  | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS | IS LEARNER |
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+------------+
|  http://127.0.0.1:2379 | 8211f1d0f64f3269 | 3.3.0+git |   20 kB |      true |         4 |         12 |                 12 |        |      false |
| http://127.0.0.1:22379 | 91636ee2a4bd28aa | 3.3.0+git |   20 kB |     false |         4 |         12 |                 12 |        |       true |
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+------------+

$ etcdctl endpoint status -w table --endpoints=http://127.0.0.1:22379
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+------------+
|        ENDPOINT        |        ID        |  VERSION  | DB SIZE | IS LEADER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS | IS LEARNER |
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+------------+
| http://127.0.0.1:22379 | 91636ee2a4bd28aa | 3.3.0+git |   20 kB |     false |         4 |         12 |                 12 |        |       true |
+------------------------+------------------+-----------+---------+-----------+-----------+------------+--------------------+--------+------------+
```
```
$ etcdctl endpoint status -w json --endpoints=http://127.0.0.1:22379
[{"Endpoint":"http://127.0.0.1:22379","Status":{"header":{"cluster_id":8228326457201596175,"member_id":10476339077899430058,"revision":1,"raft_term":4},"version":"3.3.0+git","dbSize":20480,"leader":9372538179322589801,"raftIndex":12,"raftTerm":4,"raftAppliedIndex":12,"dbSizeInUse":16384,"isLearner":true}}]
```
```
$ etcdctl endpoint status -w fields --endpoints=http://127.0.0.1:22379
"ClusterID" : 8228326457201596175
"MemberID" : 10476339077899430058
"Revision" : 1
"RaftTerm" : 4
"Version" : "3.3.0+git"
"DBSize" : 20480
"Leader" : 9372538179322589801
"RaftIndex" : 12
"RaftTerm" : 4
"RaftAppliedIndex" : 12
"Errors" : []
"Endpoint" : "http://127.0.0.1:22379"
"IsLearner" : true

```
```
$ etcdctl endpoint status --endpoints=http://127.0.0.1:22379
http://127.0.0.1:22379, 91636ee2a4bd28aa, 3.3.0+git, 20 kB, false, 4, 12, 12, , true
```
