### PR TITLE
etcdserver: filter rpc request to learner

### DIFF
--- a/etcdserver/api/v3rpc/interceptor.go
+++ b/etcdserver/api/v3rpc/interceptor.go
@@ -48,6 +48,11 @@ func newUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
 			return nil, rpctypes.ErrGRPCNotCapable
 		}
 
+		// TODO: add test in clientv3/integration to verify behavior
+		if s.IsLearner() && !isRPCEnabledForLearner(req) {
+			return nil, rpctypes.ErrGPRCNotSupportedForLearner
+		}
+
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			if ks := md[rpctypes.MetadataRequireLeaderKey]; len(ks) > 0 && ks[0] == rpctypes.MetadataHasLeader {
@@ -188,6 +193,10 @@ func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if !api.IsCapabilityEnabled(api.V3rpcCapability) {
 			return rpctypes.ErrGRPCNotCapable
+		}
+
+		if s.IsLearner() { // learner does not support Watch and LeaseKeepAlive RPC
+			return rpctypes.ErrGPRCNotSupportedForLearner
 		}
 
 		md, ok := metadata.FromIncomingContext(ss.Context())

--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -69,6 +69,7 @@ var (
 	ErrGRPCTimeoutDueToConnectionLost = status.New(codes.Unavailable, "etcdserver: request timed out, possibly due to connection lost").Err()
 	ErrGRPCUnhealthy                  = status.New(codes.Unavailable, "etcdserver: unhealthy cluster").Err()
 	ErrGRPCCorrupt                    = status.New(codes.DataLoss, "etcdserver: corrupt cluster").Err()
+	ErrGPRCNotSupportedForLearner     = status.New(codes.FailedPrecondition, "etcdserver: rpc not supported for learner").Err()
 
 	errStringToError = map[string]error{
 		ErrorDesc(ErrGRPCEmptyKey):      ErrGRPCEmptyKey,

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -22,6 +22,7 @@ import (
 	"go.etcd.io/etcd/etcdserver"
 	"go.etcd.io/etcd/etcdserver/api/membership"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
+	pb "go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"go.etcd.io/etcd/lease"
 	"go.etcd.io/etcd/mvcc"
 
@@ -115,4 +116,16 @@ func isClientCtxErr(ctxErr error, err error) bool {
 		}
 	}
 	return false
+}
+
+// in v3.4, learner is allowed to serve serializable read and endpoint status
+func isRPCEnabledForLearner(req interface{}) bool {
+	switch r := req.(type) {
+	case *pb.StatusRequest:
+		return true
+	case *pb.RangeRequest:
+		return r.Serializable
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
According to learner [design doc](https://docs.google.com/document/d/1G9Sz34iYntF9nEkyZ91qbRjyaiTxWyd5orS6xCTiQW0/edit#heading=h.knph7p2onu5a), in v3.4 implementation, learner should reject all requests other than serializable read and member status API.

This **WIP** PR does the following:
1. Hard-coded allowed rpc types for learner node.

2. Added filtering in grpc interceptor to check if rpc is allowed for learner node. Returns `ErrGPRCNotSupportedForLearner` if not allowed.

**TODO:**
- [x] Determine is this the proper way to filter rpc request to learner?
Filtering in later stage of the request handling chain will cause lots of duplicated code, as the request fans out to different servers (i.e. KV server, Lease server, Cluster server, etc) immediately after the interceptors.

- [x] The retry interceptor on **client** side will keep retry repeatedly for some of the rpc requests. Stop the retry if server returns `ErrGRPCNotCapable`?
Fixed by returning `FailedPrecondition` code. In this case, clientv3 will not retry.

- [x] Reject stream request (Watch, LeaseKeepAlive) in `StreamServerInterceptor`.
Added.

- [ ] Need to address `etcdctl endpoint health`. Currently it uses linearizable read as part of the health check.
Note: the 'health' HTTP endpoint is NOT affected by this PR, as it does not go through gRPC.
Will address in a separate PR.

- [x] Need to add tests in `clientv3/integration` to verify the intended behavior.
Will address in a separate PR.