### PR TITLE
clientv3/integration: fix cluster tests

### DIFF
--- a/clientv3/integration/cluster_test.go
+++ b/clientv3/integration/cluster_test.go
@@ -203,6 +203,16 @@ func TestMemberAddForLearner(t *testing.T) {
 	if resp.Member.IsLearner != isLearner {
 		t.Errorf("Added a member with IsLearner = %v, got %v", isLearner, resp.Member.IsLearner)
 	}
+
+	numberOfLearners := 0
+	for _, m := range resp.Members {
+		if m.IsLearner {
+			numberOfLearners++
+		}
+	}
+	if numberOfLearners != 1 {
+		t.Errorf("Added 1 learner node to cluster, got %d", numberOfLearners)
+	}
 }
 
 func TestMemberPromoteForLearner(t *testing.T) {
@@ -216,34 +226,38 @@ func TestMemberPromoteForLearner(t *testing.T) {
 
 	urls := []string{"http://127.0.0.1:1234"}
 	isLearner := true
-	resp, err := capi.MemberAdd(context.Background(), urls, isLearner)
+	memberAddResp, err := capi.MemberAdd(context.Background(), urls, isLearner)
 	if err != nil {
 		t.Fatalf("failed to add member %v", err)
 	}
 
-	if resp.Member.IsLearner != isLearner {
-		t.Errorf("Added a member with IsLearner = %v, got %v", isLearner, resp.Member.IsLearner)
+	if memberAddResp.Member.IsLearner != isLearner {
+		t.Fatalf("Added a member with IsLearner = %v, got %v", isLearner, memberAddResp.Member.IsLearner)
+	}
+	learnerID := memberAddResp.Member.ID
+
+	numberOfLearners := 0
+	for _, m := range memberAddResp.Members {
+		if m.IsLearner {
+			numberOfLearners++
+		}
+	}
+	if numberOfLearners != 1 {
+		t.Fatalf("Added 1 learner node to cluster, got %d", numberOfLearners)
 	}
 
-	learners, err := clus.GetLearnerMembers()
+	memberPromoteResp, err := capi.MemberPromote(context.Background(), learnerID)
 	if err != nil {
-		t.Fatalf("failed to get the learner members in cluster: %v", err)
-	}
-	if len(learners) != 1 {
-		t.Errorf("Added 1 learner node to cluster, got %d", len(learners))
-	}
-	_, err = capi.MemberPromote(context.Background(), resp.Member.ID)
-
-	if err != nil {
-		t.Fatalf("failed to promote member error: %v", err)
+		t.Fatalf("failed to promote member: %v", err)
 	}
 
-	learners, err = clus.GetLearnerMembers()
-	if err != nil {
-		t.Fatalf("failed to get the number of learners in cluster: %v", err)
+	numberOfLearners = 0
+	for _, m := range memberPromoteResp.Members {
+		if m.IsLearner {
+			numberOfLearners++
+		}
 	}
-	if len(learners) != 0 {
-		t.Errorf("learner promoted, expect 0 learner, got %d", len(learners))
+	if numberOfLearners != 0 {
+		t.Errorf("learner promoted, expect 0 learner, got %d", numberOfLearners)
 	}
-
 }


### PR DESCRIPTION
Fixes `TestMemberAddForLearner` and `TestMemberPromoteForLearner`.

After membership reconfiguration API call (such as MemberAdd, MemberPromote), client should not read from a different server for members list because the server might have stale information. Instead, use the members list in the response of membership reconfiguration API call.