### PR TITLE
etcdserver: make server unavailable if itself is not yet added to cluster

### DIFF
--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -57,11 +57,6 @@ type RaftCluster struct {
 	// removed contains the ids of removed members in the cluster.
 	// removed id cannot be reused.
 	removed map[types.ID]bool
-
-	// localNodeAdded is set to true when local member is added to RaftCluster via AddMember(). During
-	// starting and restarting of the server, a server might not have complete member information about
-	// itself until it applies the corresponding raft log entries which adds itself to RaftCluster.
-	localNodeAdded bool
 }
 
 // ConfigChangeContext represents a context for confChange.
@@ -364,10 +359,6 @@ func (c *RaftCluster) AddMember(m *Member) {
 	}
 
 	c.members[m.ID] = m
-
-	if m.ID == c.localID {
-		c.localNodeAdded = true
-	}
 
 	if c.lg != nil {
 		c.lg.Info(
@@ -784,13 +775,4 @@ func (c *RaftCluster) VotingMemberIDs() []types.ID {
 	}
 	sort.Sort(types.IDSlice(ids))
 	return ids
-}
-
-// IsAddedToCluster returns true if server itself is added to s.cluster via configuration apply. During
-// starting and restarting of the server, a server might not have complete member information about itself
-// until it applies the corresponding raft log entries which adds itself to s.cluster.
-func (c *RaftCluster) IsAddedToCluster() bool {
-	c.Lock()
-	defer c.Unlock()
-	return c.localNodeAdded
 }

--- a/etcdserver/api/v3rpc/interceptor.go
+++ b/etcdserver/api/v3rpc/interceptor.go
@@ -49,6 +49,10 @@ func newUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
 		}
 
 		// TODO: add test in clientv3/integration to verify behavior
+		if !s.IsAddedToCluster() {
+			// server is not ready to serve if itself is not yet added to cluster
+			return nil, rpctypes.ErrGRPCServerNotReady
+		}
 		if s.IsLearner() && !isRPCEnabledForLearner(req) {
 			return nil, rpctypes.ErrGPRCNotSupportedForLearner
 		}
@@ -195,6 +199,10 @@ func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor
 			return rpctypes.ErrGRPCNotCapable
 		}
 
+		if !s.IsAddedToCluster() {
+			// server is not ready to serve if itself is not yet added to cluster
+			return rpctypes.ErrGRPCServerNotReady
+		}
 		if s.IsLearner() { // learner does not support Watch and LeaseKeepAlive RPC
 			return rpctypes.ErrGPRCNotSupportedForLearner
 		}

--- a/etcdserver/api/v3rpc/rpctypes/error.go
+++ b/etcdserver/api/v3rpc/rpctypes/error.go
@@ -73,6 +73,7 @@ var (
 	ErrGRPCCorrupt                    = status.New(codes.DataLoss, "etcdserver: corrupt cluster").Err()
 	ErrGPRCNotSupportedForLearner     = status.New(codes.FailedPrecondition, "etcdserver: rpc not supported for learner").Err()
 	ErrGRPCBadLeaderTransferee        = status.New(codes.FailedPrecondition, "etcdserver: bad leader transferee").Err()
+	ErrGRPCServerNotReady             = status.New(codes.Unavailable, "etcdserver: server not ready").Err()
 
 	errStringToError = map[string]error{
 		ErrorDesc(ErrGRPCEmptyKey):      ErrGRPCEmptyKey,
@@ -126,7 +127,9 @@ var (
 		ErrorDesc(ErrGRPCTimeoutDueToConnectionLost): ErrGRPCTimeoutDueToConnectionLost,
 		ErrorDesc(ErrGRPCUnhealthy):                  ErrGRPCUnhealthy,
 		ErrorDesc(ErrGRPCCorrupt):                    ErrGRPCCorrupt,
+		ErrorDesc(ErrGPRCNotSupportedForLearner):     ErrGPRCNotSupportedForLearner,
 		ErrorDesc(ErrGRPCBadLeaderTransferee):        ErrGRPCBadLeaderTransferee,
+		ErrorDesc(ErrGRPCServerNotReady):             ErrGRPCServerNotReady,
 	}
 )
 

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -2500,3 +2500,10 @@ func (s *EtcdServer) Logger() *zap.Logger {
 func (s *EtcdServer) IsLearner() bool {
 	return s.cluster.IsLearner()
 }
+
+// IsAddedToCluster returns true if server itself is added to s.cluster via configuration apply. During
+// starting and restarting of the server, a server might not have complete member information about itself
+// until it applies the corresponding raft log entries which adds itself to s.cluster.
+func (s *EtcdServer) IsAddedToCluster() bool {
+	return s.cluster.IsAddedToCluster()
+}

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -2505,5 +2505,5 @@ func (s *EtcdServer) IsLearner() bool {
 // starting and restarting of the server, a server might not have complete member information about itself
 // until it applies the corresponding raft log entries which adds itself to s.cluster.
 func (s *EtcdServer) IsAddedToCluster() bool {
-	return s.cluster.IsAddedToCluster()
+	return s.cluster.IsMemberExist(s.ID())
 }


### PR DESCRIPTION
During starting and restarting of an etcd server, server should not serve client requests if itself is not yet added to the cluster.

This is especially important to learner. Because when starting the etcd process, learner node does not know itself is learner, until the corresponding raft log entry (of type `ConfChangeAddLearnerNode`) is applied locally. Before the leaner member has this information, it should not serve client requests.

After learner member knows itself is learner, it will serve certain request types based on filtering in #11.

This has less affect on voting member because we are not filtering rpc request coming to voting member. 

cc @jpbetz @gyuho @xiang90 @WIZARD-CXY