### PR TITLE
etcdserver: check IsMemberExist before IsLearner

### DIFF
--- a/etcdserver/api/v3rpc/interceptor.go
+++ b/etcdserver/api/v3rpc/interceptor.go
@@ -48,7 +48,7 @@ func newUnaryInterceptor(s *etcdserver.EtcdServer) grpc.UnaryServerInterceptor {
 			return nil, rpctypes.ErrGRPCNotCapable
 		}
 
-		if s.IsLearner() && !isRPCEnabledForLearner(req) {
+		if s.IsMemberExist(s.ID()) && s.IsLearner() && !isRPCEnabledForLearner(req) {
 			return nil, rpctypes.ErrGPRCNotSupportedForLearner
 		}
 
@@ -194,7 +194,7 @@ func newStreamInterceptor(s *etcdserver.EtcdServer) grpc.StreamServerInterceptor
 			return rpctypes.ErrGRPCNotCapable
 		}
 
-		if s.IsLearner() { // learner does not support Watch and LeaseKeepAlive RPC
+		if s.IsMemberExist(s.ID()) && s.IsLearner() { // learner does not support stream RPC
 			return rpctypes.ErrGPRCNotSupportedForLearner
 		}
 

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -2517,3 +2517,8 @@ func (s *EtcdServer) Logger() *zap.Logger {
 func (s *EtcdServer) IsLearner() bool {
 	return s.cluster.IsLearner()
 }
+
+// IsMemberExist returns if the member with the given id exists in cluster.
+func (s *EtcdServer) IsMemberExist(id types.ID) bool {
+	return s.cluster.IsMemberExist(id)
+}


### PR DESCRIPTION
Fixing a bug introduced by #11. If local member does not exist in cluster (which could happen during bootstrapping), `IsLearner()` will panic.

This check means during bootstrapping phase, learner will accept all types of requests until it is added to `s.cluster`. Tried to make learner reject request during bootstrapping (#25), did not find a feasible fix.

cc @jpbetz