### PR TITLE
etcdserver: bug fix for server forward member promote to leader

### DIFF
--- a/etcdserver/api/etcdhttp/peer.go
+++ b/etcdserver/api/etcdhttp/peer.go
@@ -130,7 +130,7 @@ func (h *peerMemberPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			http.Error(w, err.Error(), http.StatusNotFound)
 		case membership.ErrMemberNotLearner:
 			http.Error(w, err.Error(), http.StatusPreconditionFailed)
-		case membership.ErrLearnerNotReady:
+		case etcdserver.ErrLearnerNotReady:
 			http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		default:
 			WriteError(h.lg, w, r, err)

--- a/etcdserver/api/membership/errors.go
+++ b/etcdserver/api/membership/errors.go
@@ -26,7 +26,6 @@ var (
 	ErrIDNotFound       = errors.New("membership: ID not found")
 	ErrPeerURLexists    = errors.New("membership: peerURL exists")
 	ErrMemberNotLearner = errors.New("membership: can only promote a learner member")
-	ErrLearnerNotReady  = errors.New("membership: can only promote a learner member which catches up with leader")
 	ErrTooManyLearners  = errors.New("membership: too many learner members in cluster")
 )
 

--- a/etcdserver/api/v3rpc/util.go
+++ b/etcdserver/api/v3rpc/util.go
@@ -36,7 +36,6 @@ var toGRPCErrorMap = map[error]error{
 	membership.ErrIDExists:                rpctypes.ErrGRPCMemberExist,
 	membership.ErrPeerURLexists:           rpctypes.ErrGRPCPeerURLExist,
 	membership.ErrMemberNotLearner:        rpctypes.ErrGRPCMemberNotLearner,
-	membership.ErrLearnerNotReady:         rpctypes.ErrGRPCLearnerNotReady,
 	membership.ErrTooManyLearners:         rpctypes.ErrGRPCTooManyLearners,
 	etcdserver.ErrNotEnoughStartedMembers: rpctypes.ErrMemberNotEnoughStarted,
 	etcdserver.ErrLearnerNotReady:         rpctypes.ErrGRPCLearnerNotReady,

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -383,8 +383,8 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 	}
 	if resp.StatusCode == http.StatusPreconditionFailed {
 		// both ErrMemberNotLearner and ErrLearnerNotReady have same http status code
-		if strings.Contains(string(b), membership.ErrLearnerNotReady.Error()) {
-			return nil, membership.ErrLearnerNotReady
+		if strings.Contains(string(b), ErrLearnerNotReady.Error()) {
+			return nil, ErrLearnerNotReady
 		}
 		if strings.Contains(string(b), membership.ErrMemberNotLearner.Error()) {
 			return nil, membership.ErrMemberNotLearner

--- a/etcdserver/cluster_util.go
+++ b/etcdserver/cluster_util.go
@@ -395,6 +395,10 @@ func promoteMemberHTTP(ctx context.Context, url string, id uint64, peerRt http.R
 		return nil, membership.ErrIDNotFound
 	}
 
+	if resp.StatusCode != http.StatusOK { // all other types of errors
+		return nil, fmt.Errorf("member promote: unknown error(%s)", string(b))
+	}
+
 	var membs []*membership.Member
 	if err := json.Unmarshal(b, &membs); err != nil {
 		return nil, err

--- a/etcdserver/server.go
+++ b/etcdserver/server.go
@@ -1650,7 +1650,7 @@ func (s *EtcdServer) PromoteMember(ctx context.Context, id uint64) ([]*membershi
 				return resp, nil
 			}
 			// If member promotion failed, return early. Otherwise keep retry.
-			if err == membership.ErrIDNotFound || err == membership.ErrLearnerNotReady || err == membership.ErrMemberNotLearner {
+			if err == ErrLearnerNotReady || err == membership.ErrIDNotFound || err == membership.ErrMemberNotLearner {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
1. Accidentally created two types of errors of same meaning: `etcdserver.ErrLearnerNotReady` and `membership.ErrLearnerNotReady`. Use `etcdserver.ErrLearnerNotReady` in member promote HTTP, and deleted the other one.

2. In `promoteMemberHTTP()`, only unmarshall HTTP response `body` to `membership.Member` if the HTTP response `StatusCode` is `StatusOK`.

cc @jpbetz @WIZARD-CXY