### PR TITLE
integration: update TestMemberPromote test

### DIFF
--- a/clientv3/integration/cluster_test.go
+++ b/clientv3/integration/cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"go.etcd.io/etcd/integration"
 	"go.etcd.io/etcd/pkg/testutil"
@@ -215,13 +216,19 @@ func TestMemberAddForLearner(t *testing.T) {
 	}
 }
 
-func TestMemberPromoteForNotReadyLearner(t *testing.T) {
+func TestMemberPromote(t *testing.T) {
 	defer testutil.AfterTest(t)
 
-	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	clus := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 3})
 	defer clus.Terminate(t)
-	// first client is talked to leader because cluster size is 1
-	capi := clus.Client(0)
+
+	// member promote request can be sent to any server in cluster,
+	// the request will be auto-forwarded to leader on server-side.
+	// This test explicitly includes the server-side forwarding by
+	// sending the request to follower.
+	leaderIdx := clus.WaitLeader(t)
+	followerIdx := (leaderIdx + 1) % 3
+	capi := clus.Client(followerIdx)
 
 	urls := []string{"http://127.0.0.1:1234"}
 	isLearner := true
@@ -245,14 +252,45 @@ func TestMemberPromoteForNotReadyLearner(t *testing.T) {
 		t.Fatalf("Added 1 learner node to cluster, got %d", numberOfLearners)
 	}
 
-	// since we do not start learner, learner must be not ready.
+	// learner is not started yet. Expect learner progress check to fail.
+	// As the result, member promote request will fail.
 	_, err = capi.MemberPromote(context.Background(), learnerID)
 	expectedErrKeywords := "can only promote a learner member which catches up with leader"
 	if err == nil {
 		t.Fatalf("expecting promote not ready learner to fail, got no error")
 	}
 	if !strings.Contains(err.Error(), expectedErrKeywords) {
-		t.Errorf("expecting error to contain %s, got %s", expectedErrKeywords, err.Error())
+		t.Fatalf("expecting error to contain %s, got %s", expectedErrKeywords, err.Error())
+	}
+
+	// create and launch learner member based on the response of V3 Member Add API.
+	// (the response has information on peer urls of the existing members in cluster)
+	learnerMember := clus.MustNewMember(t, memberAddResp)
+	clus.Members = append(clus.Members, learnerMember)
+	if err := learnerMember.Launch(); err != nil {
+		t.Fatal(err)
+	}
+
+	// retry until promote succeed or timeout
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-timeout:
+			t.Errorf("failed all attempts to promote learner member, last error: %v", err)
+			break
+		}
+
+		_, err = capi.MemberPromote(context.Background(), learnerID)
+		// successfully promoted learner
+		if err == nil {
+			break
+		}
+		// if member promote fails due to learner not ready, retry.
+		// otherwise fails the test.
+		if !strings.Contains(err.Error(), expectedErrKeywords) {
+			t.Fatalf("unexpected error when promoting learner member: %v", err)
+		}
 	}
 }
 

--- a/etcdserver/server_test.go
+++ b/etcdserver/server_test.go
@@ -1340,54 +1340,6 @@ func TestRemoveMember(t *testing.T) {
 	}
 }
 
-// TestPromoteMember tests PromoteMember can propose and perform learner node promotion.
-func TestPromoteMember(t *testing.T) {
-	n := newNodeConfChangeCommitterRecorder()
-	n.readyc <- raft.Ready{
-		SoftState: &raft.SoftState{RaftState: raft.StateLeader},
-	}
-	cl := newTestCluster(nil)
-	st := v2store.New()
-	cl.SetStore(v2store.New())
-	cl.AddMember(&membership.Member{
-		ID: 1234,
-		RaftAttributes: membership.RaftAttributes{
-			IsLearner: true,
-		},
-	})
-	r := newRaftNode(raftNodeConfig{
-		lg:          zap.NewExample(),
-		Node:        n,
-		raftStorage: raft.NewMemoryStorage(),
-		storage:     mockstorage.NewStorageRecorder(""),
-		transport:   newNopTransporter(),
-	})
-	s := &EtcdServer{
-		lgMu:       new(sync.RWMutex),
-		lg:         zap.NewExample(),
-		r:          *r,
-		v2store:    st,
-		cluster:    cl,
-		reqIDGen:   idutil.NewGenerator(0, time.Time{}),
-		SyncTicker: &time.Ticker{},
-	}
-	s.start()
-	_, err := s.PromoteMember(context.TODO(), 1234)
-	gaction := n.Action()
-	s.Stop()
-
-	if err != nil {
-		t.Fatalf("PromoteMember error: %v", err)
-	}
-	wactions := []testutil.Action{{Name: "ProposeConfChange:ConfChangeAddNode"}, {Name: "ApplyConfChange:ConfChangeAddNode"}}
-	if !reflect.DeepEqual(gaction, wactions) {
-		t.Errorf("action = %v, want %v", gaction, wactions)
-	}
-	if cl.Member(1234).IsLearner {
-		t.Errorf("member with id 1234 is not promoted")
-	}
-}
-
 // TestUpdateMember tests RemoveMember can propose and perform node update.
 func TestUpdateMember(t *testing.T) {
 	n := newNodeConfChangeCommitterRecorder()

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -1396,3 +1396,18 @@ func (p SortableProtoMemberSliceByPeerURLs) Less(i, j int) bool {
 	return p[i].PeerURLs[0] < p[j].PeerURLs[0]
 }
 func (p SortableProtoMemberSliceByPeerURLs) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+
+// MustNewMember creates a new member instance based on the response of V3 Member Add API.
+func (c *ClusterV3) MustNewMember(t testing.TB, resp *clientv3.MemberAddResponse) *member {
+	m := c.mustNewMember(t)
+	m.isLearner = resp.Member.IsLearner
+	m.NewCluster = false
+
+	m.InitialPeerURLsMap = types.URLsMap{}
+	for _, mm := range c.Members {
+		m.InitialPeerURLsMap[mm.Name] = mm.PeerURLs
+	}
+	m.InitialPeerURLsMap[m.Name] = types.MustNewURLs(resp.Member.PeerURLs)
+
+	return m
+}


### PR DESCRIPTION
@WIZARD-CXY
I was trying to modify the integration test to verify learner promotion. The behavior is very strange, I was not able to finish debugging. Could you also help to take a look?

1. I did a very similar test manually, everything worked as expected. To be specific, I did the following test:
1.1) start etcd 1 and etcd 2.
1.2) use etcdctl to add 3rd server as learner
1.3) use etcdctl to send member promote request to either etcd 1 or etcd 2, the request was successfully forwarded to leader (if needed), and an error of ErrLearnerNotReady was returned.
1.4) start 3rd server, now it can be promoted via etcdctl. Again, the request can be sent to either etcd 1 or 2.

2. In this integration test, it does not work as expected. I posted part of the test output in the end (I added prints in the code). Basically, the member promote request was sent to a follower, and it was then forwarded to leader. But `raftStatus()` on leader always pulls status from a different raft node. It looks to me that something is strange about how `raftStatus()` or `expvar` works. Could you help take a look? We might end up needing to expose Progress via `ready`.

My local test result (partial):
```
=== RUN   TestMemberPromoteForLearner
2019-05-07 18:12:45.811128 I | etcdserver: cc2edbf8cc9f1fc1: raftStatus = {"id":"f5b9396603b8370f","term":2,"vote":"759a96384fc9f657","commit":10,"lead":"759a96384fc9f657","raftState":"StateFollower","applied":10,"progress":{},"leadtransferee":"0"}
2019-05-07 18:12:45.811144 I | etcdserver: cc2edbf8cc9f1fc1: resp = [], err = etcdserver: not leader
2019-05-07 18:12:45.811158 I | etcdserver: cc2edbf8cc9f1fc1: forwarding to leader &{ID:759a96384fc9f657 RaftAttributes:{PeerURLs:[unix://127.0.0.1:2100147587] IsLearner:false} Attributes:{Name:4049563206422264687 ClientURLs:[unix://127.0.0.1:2100247587]}}
2019-05-07 18:12:45.811320 I | etcdserver: 759a96384fc9f657: raftStatus = {"id":"f5b9396603b8370f","term":2,"vote":"759a96384fc9f657","commit":10,"lead":"759a96384fc9f657","raftState":"StateFollower","applied":10,"progress":{},"leadtransferee":"0"}
2019-05-07 18:12:45.811327 I | etcdserver: 759a96384fc9f657: resp = [], err = etcdserver: not leader
2019-05-07 18:12:45.811335 I | etcdserver: 759a96384fc9f657: forwarding to leader &{ID:759a96384fc9f657 RaftAttributes:{PeerURLs:[unix://127.0.0.1:2100147587] IsLearner:false} Attributes:{Name:4049563206422264687 ClientURLs:[unix://127.0.0.1:2100247587]}}
2019-05-07 18:12:45.811457 I | etcdserver: 759a96384fc9f657: raftStatus = {"id":"f5b9396603b8370f","term":2,"vote":"759a96384fc9f657","commit":10,"lead":"759a96384fc9f657","raftState":"StateFollower","applied":10,"progress":{},"leadtransferee":"0"}
2019-05-07 18:12:45.811463 I | etcdserver: 759a96384fc9f657: resp = [], err = etcdserver: not leader
2019-05-07 18:12:45.811470 I | etcdserver: 759a96384fc9f657: forwarding to leader &{ID:759a96384fc9f657 RaftAttributes:{PeerURLs:[unix://127.0.0.1:2100147587] IsLearner:false} Attributes:{Name:4049563206422264687 ClientURLs:[unix://127.0.0.1:2100247587]}}
2019-05-07 18:12:45.811582 I | etcdserver: 759a96384fc9f657: raftStatus = {"id":"f5b9396603b8370f","term":2,"vote":"759a96384fc9f657","commit":10,"lead":"759a96384fc9f657","raftState":"StateFollower","applied":10,"progress":{},"leadtransferee":"0"}
...
...
...
2019-05-07 18:12:52.186798 I | etcdserver: 759a96384fc9f657: resp = [], err = Post http://127.0.0.1:2100147587/members/promote/11575123635580679458: context canceled
--- FAIL: TestMemberPromoteForLearner (6.64s)
    cluster_test.go:262: expecting error to contain can only promote a learner member which catches up with leader, got etcdserver: request timed out
FAIL
```
